### PR TITLE
Drop support for Django 1.9 and add support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,12 @@ addons:
 env:
 
   - TOX_ENV=py27-django18
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py27-django110
   - TOX_ENV=py27-django111
 
   - TOX_ENV=py34-django18
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py34-django110
   - TOX_ENV=py34-django111
 
   - TOX_ENV=py35-django18
-  - TOX_ENV=py35-django19
-  - TOX_ENV=py35-django110
   - TOX_ENV=py35-django111
 
   - TOX_ENV=py36-django111

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,20 +19,20 @@ env:
 
   - TOX_ENV=py27-django18
   - TOX_ENV=py27-django19
-  #- TOX_ENV=py27-django110
-  #- TOX_ENV=py27-django111
+  - TOX_ENV=py27-django110
+  - TOX_ENV=py27-django111
 
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
-  #- TOX_ENV=py34-django110
-  #- TOX_ENV=py34-django111
+  - TOX_ENV=py34-django110
+  - TOX_ENV=py34-django111
 
   - TOX_ENV=py35-django18
   - TOX_ENV=py35-django19
-  #- TOX_ENV=py35-django110
-  #- TOX_ENV=py35-django111
+  - TOX_ENV=py35-django110
+  - TOX_ENV=py35-django111
 
-  #- TOX_ENV=py36-django111
+  - TOX_ENV=py36-django111
 
   - TOX_ENV=coverage
 install:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'easy_thumbnails',
     'django-guardian>=1.4.2,<=1.4.9',
     'html2text==2014.12.29',
-    'Django>=1.8,<1.10'
+    'Django>=1.8,<2.0'
 ]
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     django18: django==1.8.18
     django19: django==1.9.13
     django110: django==1.10.8
-    django111: django==1.11.7
+    django111: django==1.11.10
     coverage: django==1.9.13
     coverage: pytest-cov==2.5.1
     coverage: coveralls==1.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     ; py27 still has the widest django support
-    py27-django{18,19,110,111}
+    py27-django{18,111}
     ; py34 support was officially introduced in django1.7
-    py34-django{18,19,110,111}
+    py34-django{18,111}
     ; py35 support was officially introduced in django1.8
-    py35-django{18,19,110,111}
+    py35-django{18,111}
     ; py36 support was officially introduced in django1.11
     py36-django{111}
 
@@ -14,10 +14,8 @@ usedevelop = True
 deps =
     pytest-django==3.1.2
     django18: django==1.8.18
-    django19: django==1.9.13
-    django110: django==1.10.8
     django111: django==1.11.10
-    coverage: django==1.9.13
+    coverage: django==1.11.10
     coverage: pytest-cov==2.5.1
     coverage: coveralls==1.2.0
 

--- a/userena/fixtures/users.json
+++ b/userena/fixtures/users.json
@@ -12,7 +12,7 @@
       "last_login": "2010-08-18T03:07:03.019Z",
       "groups": [],
       "user_permissions": [],
-      "password": "sha1$645fd$8d18b38b96f72363bc9438bc1d340081b87e0fbe",
+      "password": "pbkdf2_sha256$30000$plJf3ewQmEyG$1Pub0ijE5sMzuhhUXzumj/lTiBvvOljqhDyPL7aFLBA=",
       "email": "john@example.com",
       "date_joined": "2010-08-17T10:31:55.019Z"
     }
@@ -30,7 +30,7 @@
       "last_login": "2010-08-18T03:15:19.019Z",
       "groups": [],
       "user_permissions": [],
-      "password": "sha1$645fd$8d18b38b96f72363bc9438bc1d340081b87e0fbe",
+      "password": "pbkdf2_sha256$30000$plJf3ewQmEyG$1Pub0ijE5sMzuhhUXzumj/lTiBvvOljqhDyPL7aFLBA=",
       "email": "jane@example.com",
       "date_joined": "2010-08-18T03:13:57.019Z"
     }


### PR DESCRIPTION
Django 1.9 has now reached EOL.