### PR TITLE
Fixed documentation import errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,15 +12,16 @@
 # serve to show the default.
 
 import sys, os
+import django
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.append(os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('..'))
 sys.path.append(os.path.abspath('../demo'))
 userena = __import__('userena')
-demo = __import__('demo')
 os.environ['DJANGO_SETTINGS_MODULE'] = 'demo.settings'
+django.setup()
 
 
 # -- General configuration -----------------------------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -233,12 +233,14 @@ Django admin screen (e.g. http://<yoursite.com>/admin/sites/ ) and then
 put the id for that site in the SITE_ID setting variable.:
 
 .. code-block:: python
+
    SITE_ID = <site.id of your site> # will probably be '1' if this is your 
                                     # first.
                                     
 To look up your site_id open a shell in manage.py (manage.py shell) and:
 
 .. code-block:: python
+
    from django.contrib.sites.models import Site
    for s in Site.objects.all():
       print "id: {0}  name: {1}".format(s.id, s.name)

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,10 @@
+# If you want to work on the documentation, you will need at least these 
+#  packages they are not pinned to any particular version because you might be
+#  working on the docs at some point in the future.
+
+Django
+django-guardian
+easy-thumbnails
+html2text
+htmltext
+Sphinx

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ except IOError:
 
 def django_guardian_version():
     if sys.version_info < (3,5):
-        return 'django-guardian<2'
+        # Django Guardian does not support Python < 3.5 after version 2
+        return 'django-guardian>=1.4.2,<2'
     else:
         return 'django-guardian>=1.4.2'
 

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,16 @@ except IOError:
     )
     sys.exit(1)
 
+
+def django_guardian_version():
+    if sys.version_info < (3,5):
+        return 'django-guardian<2'
+    else:
+        return 'django-guardian>=1.4.2'
+
 install_requires = [
     'easy_thumbnails',
-    'django-guardian>=1.4.2',
+    django_guardian_version(),
     'html2text',
     'Django>=1.11',
 ]


### PR DESCRIPTION
If you look at: https://django-userena-ce.readthedocs.io/en/latest/api/middleware.html#userenalocalemiddleware

You can see the documentation is missing.  This is not because the comments don't exist in the source but because the setup in conf.py is not correct.  This fixes that problem so that the auto doc stuff just works.
