### PR TITLE
Do not overuse 'Account disabled'

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -152,6 +152,9 @@ class UserenaSignup(models.Model):
         mailer.generate_mail("confirmation", "_new")
         mailer.send_mail(self.email_unconfirmed)
 
+    def activation_complected(self):
+        return self.activation_key == userena_settings.USERENA_ACTIVATED
+
     def activation_key_expired(self):
         """
         Checks if activation key is expired.
@@ -168,9 +171,8 @@ class UserenaSignup(models.Model):
             days=userena_settings.USERENA_ACTIVATION_DAYS
         )
         expiration_date = self.user.date_joined + expiration_days
-        if self.activation_key == userena_settings.USERENA_ACTIVATED:
-            return True
-        if get_datetime_now() >= expiration_date:
+        if self.activation_complected() or \
+           get_datetime_now() >= expiration_date:
             return True
         return False
 

--- a/userena/templates/userena/activation_pending.html
+++ b/userena/templates/userena/activation_pending.html
@@ -4,6 +4,6 @@
 {% block title %}{% trans "Not activated " %}{% endblock %}
 {% block content_title %}<h2>{% trans "Your account has not been activiated yet" %}</h2>{% endblock %}
 {% block content %}
-<p>{% trans "It seems you have not completed the activiation steps for your accounts." %}</p>
-<p>{% trans "If, for any reason, you are unable to complete the activiation steps, please contact the administrators for assistance." %}</p>
+<p>{% trans "It seems you have not completed the activation steps for your accounts." %}</p>
+<p>{% trans "If, for any reason, you are unable to complete the activation steps, please contact the administrators for assistance." %}</p>
 {% endblock %}

--- a/userena/templates/userena/activiation_pending.html
+++ b/userena/templates/userena/activiation_pending.html
@@ -1,0 +1,9 @@
+{% extends 'userena/base_userena.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Not activated " %}{% endblock %}
+{% block content_title %}<h2>{% trans "Your account has not been activiated yet" %}</h2>{% endblock %}
+{% block content %}
+<p>{% trans "It seems you have not completed the activiation steps for your accounts." %}</p>
+<p>{% trans "If, for any reason, you are unable to complete the activiation steps, please contact the administrators for assistance." %}</p>
+{% endblock %}

--- a/userena/urls.py
+++ b/userena/urls.py
@@ -99,6 +99,12 @@ urlpatterns = [
         userena_views.disabled_account,
         name="userena_disabled",
     ),
+    # Activation pending
+    url(
+        r"^(?P<username>[\@\.\+\w-]+)/pending/$",
+        userena_views.activation_pending,
+        name="userena_activation_pending",
+    ),
     # Change password
     url(
         r"^(?P<username>[\@\.\+\w-]+)/password/$",

--- a/userena/urls.py
+++ b/userena/urls.py
@@ -97,7 +97,6 @@ urlpatterns = [
     url(
         r"^(?P<username>[\@\.\+\w-]+)/disabled/$",
         userena_views.disabled_account,
-        {"template_name": "userena/disabled.html"},
         name="userena_disabled",
     ),
     # Change password

--- a/userena/views.py
+++ b/userena/views.py
@@ -423,7 +423,16 @@ def disabled_account(request,
                      template_name="userena/disabled.html",
                      extra_context=None):
     """
-    Checks if the account is not active, if so, returns the disabled account template.
+    Checks if the account is not active, if so, returns the disabled
+    account template.
+
+    The ``disabled_account`` view has a high bar: it should only be
+    shown if the user has a completed activiation.  Otherwise,
+    redirect to `userena_activation_pending``.
+
+    If no ``UserenaSignup`` object can be found for the user, we will
+    still assume that it was deleted after expiration but not that
+    account was deliberately disabled.
 
     :param username:
         String defining the username of the user that made the action.
@@ -448,10 +457,19 @@ def disabled_account(request,
         Profile of the viewed user.
 
     """
-    user = get_object_or_404(get_user_model(), username__iexact=username)
+    user = get_object_or_404(get_user_model(), username__iexact=username,
+                             is_active=False)
 
-    if user.is_active:
-        raise Http404
+    try:
+        userena = UserenaSignup.objects.get(user=user)
+    except UserenaSignup.DoesNotExist:
+        userena = None
+
+    if not userena or not userena.activation_complected():
+        return redirect(
+            reverse("userena_activation_pending",
+                    kwargs={"username": user.username})
+        )
 
     if not extra_context:
         extra_context = dict()
@@ -461,6 +479,63 @@ def disabled_account(request,
         template_name=template_name, extra_context=extra_context
     )(request)
 
+def activation_pending(request,
+                       username,
+                       template_name="userena/activiation_pending.html",
+                       extra_context=None):
+    """
+    Checks if the account is not active, if so, returns the
+    activation pending template.  This view is meant to take
+    precencent over the ``disabled_account`` view unless we know that the account was disabled after completion.
+
+    :param username:
+        String defining the username of the user that made the action.
+
+    :param template_name:
+        String defining the name of the template to use. Defaults to
+        ``userena/activiation_pending.html``.
+
+    **Keyword arguments**
+
+    ``extra_context``
+        A dictionary containing extra variables that should be passed to the
+        rendered template. The ``account`` key is always the ``User``
+        that completed the action.
+
+    **Extra context**
+
+    ``viewed_user``
+        The currently :class:`User` that is viewed.
+
+    ``profile``
+        Profile of the viewed user.
+
+    """
+    user = get_object_or_404(get_user_model(), username__iexact=username,
+                             is_active=False)
+
+    try:
+        userena = UserenaSignup.objects.get(user=user)
+    except UserenaSignup.DoesNotExist:
+        userena = None
+
+    # If we know that the activiation process was completed, but the
+    # user is now not active, it is safe to assume that the user was
+    # actually disbaled after completion of activiation.  In that
+    # case, we will redirec to ``userena_disabled``.
+    if userena and userena.activation_complected():
+        return redirect(
+            reverse("userena_disabled",
+                    kwargs={"username": user.username})
+        )
+
+    if not extra_context:
+        extra_context = dict()
+    extra_context["viewed_user"] = user
+    extra_context["profile"] = get_user_profile(user=user)
+    return ExtraContextTemplateView.as_view(
+        template_name=template_name, extra_context=extra_context
+    )(request)
 
 @secure_required
 def signin(
@@ -547,9 +622,24 @@ def signin(
                 )
                 return HttpResponseRedirect(redirect_to)
             else:
-                return redirect(
-                    reverse("userena_disabled", kwargs={"username": user.username})
-                )
+                try:
+                    userena = UserenaSignup.objects.get(user=user)
+                except UserenaSignup.DoesNotExist:
+                    userena = None
+                # If the user is inactive, despiting completing the
+                # activiation process, show the 'Account disabled'
+                # page.  Otherwise, show the 'Activation pending'
+                # page to encourge activiation.
+                if userena and userena.activation_complected():
+                    return redirect(
+                        reverse("userena_disabled",
+                                kwargs={"username": user.username})
+                    )
+                else:
+                    return redirect(
+                        reverse("userena_activation_pending",
+                                kwargs={"username": user.username})
+                    )
 
     if not extra_context:
         extra_context = dict()

--- a/userena/views.py
+++ b/userena/views.py
@@ -418,16 +418,19 @@ def direct_to_user_template(request, username, template_name, extra_context=None
     )(request)
 
 
-def disabled_account(request, username, template_name, extra_context=None):
+def disabled_account(request,
+                     username,
+                     template_name="userena/disabled.html",
+                     extra_context=None):
     """
-    Checks if the account is disabled, if so, returns the disabled account template.
+    Checks if the account is not active, if so, returns the disabled account template.
 
     :param username:
         String defining the username of the user that made the action.
 
     :param template_name:
         String defining the name of the template to use. Defaults to
-        ``userena/signup_complete.html``.
+        ``userena/disabled.html``.
 
     **Keyword arguments**
 

--- a/userena/views.py
+++ b/userena/views.py
@@ -427,7 +427,7 @@ def disabled_account(request,
     account template.
 
     The ``disabled_account`` view has a high bar: it should only be
-    shown if the user has a completed activiation.  Otherwise,
+    shown if the user has a completed activation.  Otherwise,
     redirect to `userena_activation_pending``.
 
     If no ``UserenaSignup`` object can be found for the user, we will
@@ -481,7 +481,7 @@ def disabled_account(request,
 
 def activation_pending(request,
                        username,
-                       template_name="userena/activiation_pending.html",
+                       template_name="userena/activation_pending.html",
                        extra_context=None):
     """
     Checks if the account is not active, if so, returns the
@@ -493,7 +493,7 @@ def activation_pending(request,
 
     :param template_name:
         String defining the name of the template to use. Defaults to
-        ``userena/activiation_pending.html``.
+        ``userena/activation_pending.html``.
 
     **Keyword arguments**
 
@@ -519,9 +519,9 @@ def activation_pending(request,
     except UserenaSignup.DoesNotExist:
         userena = None
 
-    # If we know that the activiation process was completed, but the
+    # If we know that the activation process was completed, but the
     # user is now not active, it is safe to assume that the user was
-    # actually disbaled after completion of activiation.  In that
+    # actually disbaled after completion of activation.  In that
     # case, we will redirec to ``userena_disabled``.
     if userena and userena.activation_complected():
         return redirect(
@@ -627,9 +627,9 @@ def signin(
                 except UserenaSignup.DoesNotExist:
                     userena = None
                 # If the user is inactive, despiting completing the
-                # activiation process, show the 'Account disabled'
+                # activation process, show the 'Account disabled'
                 # page.  Otherwise, show the 'Activation pending'
-                # page to encourge activiation.
+                # page to encourge activation.
                 if userena and userena.activation_complected():
                     return redirect(
                         reverse("userena_disabled",


### PR DESCRIPTION
One of the major confusions for end users upon using userena is its tendency to show the 'Account disabled' template for users who login immediately after creating an account without following the activation process.  The `disabled.html` template states: 
> If you feel that injustice has been done to you, feel free to contact the administrators to find out why

This template is too strong for people who simply did not click the sent activation link.  I have received many messages from discouraged users.

This pull request adds an `activation_pending` view and gives its precedence over the `disabled_account` view which simply encourages people to activate their accounts. At the same time, the `disabled_account` view still has its place: if we have a completed `UserenaSignup` in associaiton with an inactive user (`user.is_active == False`).