### PR TITLE
avoid django UnorderedObjectListWarning: Pagination may yield inconsi…

### DIFF
--- a/userena/managers.py
+++ b/userena/managers.py
@@ -317,4 +317,5 @@ class UserenaBaseProfileManager(models.Manager):
             profiles = profiles.exclude(Q(privacy="closed") | Q(privacy="registered"))
         else:
             profiles = profiles.exclude(Q(privacy="closed"))
+        profiles = profiles.order_by('user_id')
         return profiles


### PR DESCRIPTION
avoid django UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list