### PR TITLE
Bugfix/profiles unordered queryset

### DIFF
--- a/userena/managers.py
+++ b/userena/managers.py
@@ -317,4 +317,5 @@ class UserenaBaseProfileManager(models.Manager):
             profiles = profiles.exclude(Q(privacy="closed") | Q(privacy="registered"))
         else:
             profiles = profiles.exclude(Q(privacy="closed"))
+        profiles = profiles.order_by('user_id')
         return profiles

--- a/userena/managers.py
+++ b/userena/managers.py
@@ -317,5 +317,6 @@ class UserenaBaseProfileManager(models.Manager):
             profiles = profiles.exclude(Q(privacy="closed") | Q(privacy="registered"))
         else:
             profiles = profiles.exclude(Q(privacy="closed"))
-        profiles = profiles.order_by('user_id')
+        if not self.model._meta.ordering:
+            profiles = profiles.order_by('id')
         return profiles


### PR DESCRIPTION
You are true. I am Django beginner only.
What about this one solution?
If Meta gives ordering then it run with that one,
otherwise the pagination error is fixed (and profiles listed starting from the oldest profiles).

I would like to see the solution in the code not in the changed documentation. 2nd thing is that I am not so good in english to write documentation.
The other solution in code would be to assert on that place or produce own (userena's) warning: "please, set Profile._meta.ordering").

(btw: If this is so, that the results for pagination are unstable without given order, it would be better if django itself will decide to set _meta.ordering=['id'] (if not set yet) to avoid this problem. Otherwise on many places this should be handled/fixed/asserted.)