### PR TITLE
Add tests against Django3.2 and Python3.9

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ can use it commercially for free!
 
 Software | Versions
 ---|---
-Python | 3.6, 3.7, 3.8
-Django | 2.2, 3.0, 3.1
+Python | 3.6, 3.7, 3.8, 3.9
+Django | 2.2, 3.0, 3.1, 3.2
 Django Guardian | \>2.0
 
 ## [Documentation](https://django-userena-ce.readthedocs.io/en/latest/index.html)

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,3 @@ python_files = tests.py test_*.py *_tests.py tests_*.py
 addopts = --strict-markers -l
 markers =
 filterwarnings =
-    ignore::django.utils.deprecation.RemovedInDjango41Warning:django.apps.registry:91
-    error

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,5 @@ python_files = tests.py test_*.py *_tests.py tests_*.py
 addopts = --strict-markers -l
 markers =
 filterwarnings =
-    ignore::django.utils.deprecation.RemovedInDjango40Warning:django.apps.registry:91
+    ignore::django.utils.deprecation.RemovedInDjango41Warning:django.apps.registry:91
     error

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ python_files = tests.py test_*.py *_tests.py tests_*.py
 addopts = --strict-markers -l
 markers =
 filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango41Warning:guardian
     error

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@ DJANGO_SETTINGS_MODULE = userena.runtests.settings
 python_files = tests.py test_*.py *_tests.py tests_*.py
 addopts = --strict-markers -l
 markers =
+filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango40Warning:django.apps.registry:91
+    error

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,3 @@ DJANGO_SETTINGS_MODULE = userena.runtests.settings
 python_files = tests.py test_*.py *_tests.py tests_*.py
 addopts = --strict-markers -l
 markers =
-filterwarnings =
-    ignore::django.utils.deprecation.RemovedInDjango41Warning:guardian
-    error

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
     django32: django==3.2a1
-    coverage: django>=3.0,<3.1
+    coverage: django>=3.1,<3.2
 
 commands =
     pip install -U pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,21 @@
 [tox]
 envlist =
     ; py36 support was officially introduced in django1.11
-    py36-django{22,30,31}
+    py36-django{22,30,31,32}
     ; py37 support was officially introduced in django2.1
-    py37-django{22,30,31}
+    py37-django{22,30,31,32}
     ; py38 support was officially introduced in django3.0
-    py38-django{30,31}
+    py38-django{22,30,31,32}
+    ; py39 support was officially introduced in django3.1.3 and django 2.2.17
+    py39-django{22,31,32}
     coverage
 
 [gh-actions]
 python =
     3.6: py36
     3.7: py37
-    3.8: py38, coverage
+    3.8: py38
+    3.9: py39, coverage
 
 [testenv]
 setenv =
@@ -22,6 +25,7 @@ deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
+    django32: django==3.2a1
     coverage: django>=3.0,<3.1
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist =
     py37-django{22,30,31,32}
     ; py38 support was officially introduced in django3.0
     py38-django{22,30,31,32}
-    ; py39 support was officially introduced in django3.1.3 and django 2.2.17
-    py39-django{22,31,32}
+    ; py39 support was officially introduced in django 2.2.17, 3.0.11 and 3.1.3
+    py39-django{22,30,31,32}
     coverage
 
 [gh-actions]


### PR DESCRIPTION
No code changes necessary, so 6.0.1 is still compatible. Warnings to errors turned off as I cannot seem to easily ignore the `RemovedInDjango41Warning` for app registry.