### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -15,6 +13,10 @@ repos:
       - id: pyupgrade
         language: python
         args: [--py37-plus]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/ambv/black
     rev: 22.1.0
     hooks:
@@ -27,7 +29,6 @@ repos:
         language: python
         additional_dependencies:
           - flake8-bugbear
-          - flake8-import-order
           - pep8-naming
           - flake8-docstrings
           - mccabe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ sphinx = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+profile = "black"
+known_first_party = ["userena"]
+line_length = 79
+
 [tool.black]
 line-length = 79
 target-version = ["py37"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
 [flake8]
 max-line-length = 79
-application-import-names =
-    userena
-import-order-style = pycharm
 docstring-convention = numpy
 max-complexity = 10
 select =

--- a/userena/contrib/umessages/models.py
+++ b/userena/contrib/umessages/models.py
@@ -6,8 +6,7 @@ from userena.contrib.umessages.managers import (
     MessageManager,
     MessageRecipientManager,
 )
-from userena.utils import truncate_words
-from userena.utils import user_model_label
+from userena.utils import truncate_words, user_model_label
 
 
 class MessageContact(models.Model):

--- a/userena/contrib/umessages/views.py
+++ b/userena/contrib/umessages/views.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
-from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth import get_user_model
+from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse

--- a/userena/forms.py
+++ b/userena/forms.py
@@ -3,8 +3,7 @@ from collections import OrderedDict
 from hashlib import sha1
 
 from django import forms
-from django.contrib.auth import authenticate
-from django.contrib.auth import get_user_model
+from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import gettext_lazy as _
 
 from userena import settings as userena_settings

--- a/userena/models.py
+++ b/userena/models.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import datetime
 
 from django.conf import settings
@@ -10,6 +9,7 @@ from easy_thumbnails.fields import ThumbnailerImageField
 from guardian.shortcuts import get_perms
 
 from userena import settings as userena_settings
+from userena.mail import UserenaConfirmationMail
 from userena.managers import UserenaBaseProfileManager, UserenaManager
 from userena.utils import (
     generate_nonce,
@@ -18,7 +18,6 @@ from userena.utils import (
     get_protocol,
     user_model_label,
 )
-from .mail import UserenaConfirmationMail
 
 PROFILE_PERMISSIONS = (("view_profile", "Can view profile"),)
 

--- a/userena/tests/tests_forms.py
+++ b/userena/tests/tests_forms.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from django.utils.translation import gettext_lazy as _, override
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import override
 
 from userena import forms
 from userena import settings as userena_settings

--- a/userena/views.py
+++ b/userena/views.py
@@ -4,10 +4,10 @@ from django.contrib import messages
 from django.contrib.auth import (
     REDIRECT_FIELD_NAME,
     authenticate,
+    get_user_model,
     login,
     logout,
 )
-from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.views import LogoutView
 from django.contrib.messages.views import SuccessMessageMixin


### PR DESCRIPTION
This PR adds isort with the following changes:

- [x] `default_language_version` removed
- [x] pyupgrade args set correctly
- [x] `isort` added before `black`
- [x] `flake8-import-order` removed
- [x] `known_first_party` set correctly
- [x] `application-import-names` and `import-order-style` removed