### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # UPDATES
 
+## Unreleased
+
+- Added support for Python 3.12
+
 ## Version 7.0.3
 
 - Removed support for Python 3.7, Django 4.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ can use it commercially for free!
 
 Software | Versions
 ---|---
-Python | 3.8, 3.9, 3.10, 3.11
+Python | 3.8, 3.9, 3.10, 3.11, 3.12
 Django | 3.2, 4.1, 4.2
 Django Guardian | \>2.0
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation.
 
 Before install django-userena-ce, you'll need to have a copy of `Django
 <http://www.djangoproject.com>`_ 3.2, 4.1, 4.2 installed. django-userena-ce is
-tested under Python 3.8, 3.9, 3.10 or 3.11.
+tested under Python 3.8, 3.9, 3.10, 3.11 or 3.12.
 
 For further information, consult the `Django download page
 <http://www.djangoproject.com/download/>`_, which offers convenient packaged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,10 @@ envlist =
     py310-django{32,41,42}
     ; py311 was introduced in django 4.1.3
     py311-django{41,42}
+    ; py312 was introduced in django 4.2.8
+    py312-django{42}
     coverage
+
 
 [gh-actions]
 python =
@@ -81,6 +84,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311, coverage
+    3.12: py312
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
Support Python 3.12 as introduced in Django 4.2.8.

Reference: https://docs.djangoproject.com/en/dev/releases/4.2.8/




